### PR TITLE
fix: Initialize Assignments and Status if undefined

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,10 +16,13 @@
       "args": [
         //"-x", "./test/MEP q4 2019 19419.xlsm",
         //"-x", "./test/Shatikha 2 P&P Oct 22.xlsm",
-        "-x", "./test/Planning & Progress form 19Aug16 (3).xlsm",
-        "-u", "Darcy Wong",
+        //"-x", "./test/Planning & Progress form 19Aug16 (3).xlsm",
+        "-x", "./test/test Palaung q4 2020.xlsm",
+        //"-u", "Darcy Wong",
+        "-u", "Scott Dysart",
         //"-q", "Q3", 
-        "-p", "C:\\My Paratext 9 Projects\\MEP"
+        //"-p", "C:\\My Paratext 9 Projects\\MEP"
+        "-p", "C:\\My Paratext 8 Projects\\PTP_test"
       ]
     }
   ]

--- a/src/paratextProgress.ts
+++ b/src/paratextProgress.ts
@@ -84,12 +84,13 @@ export class ParatextProgress {
             if (Array.isArray(task)) {
               task = xmlObj.ProgressInfo.Stages.Stage[stageIndex].Task[0];
             }
+
             // Update Assignments node.
-            let assignmentsArray = task.Assignments
-            if (assignmentsArray === undefined) {
-              console.warn("Error updating assignments for " + bookCode + " in phase " + ppPhase + ". Skipping...")
-              continue;
+            if (task.Assignments === undefined) {
+              console.warn("Warning: Assignments undefined for " + bookCode + " in phase " + ppPhase + ". Initializing...")
+              task.Assignments = [];
             }
+            let assignmentsArray = task.Assignments
             // Convert from JSON to JSONArray as needed so we can push new assignments
             if (!Array.isArray(assignmentsArray)) {
               task.Assignments = [task.Assignments]
@@ -104,11 +105,11 @@ export class ParatextProgress {
             }
 
             // Update Status node.
-            let statusArray: projectStatusType[] = task.Status
-            if (statusArray === undefined) {
-              console.warn("Error updating status for " + bookCode + " in phase " + ppPhase + ". Skipping...")
-              continue;
+            if (task.Status === undefined) {
+              console.warn("Warning: Status undefined for " + bookCode + " in phase " + ppPhase + ". Initializing...")
+              task.Status = []
             }
+            let statusArray: projectStatusType[] = task.Status
             // Convert from JSON to JSONArray as needed so we can push new status
             if (!Array.isArray(statusArray)) {
               task.Status = [task.Status]


### PR DESCRIPTION
For testing with PTP_test project, the Assignments and Status arrays were undefined and need to be initialized.